### PR TITLE
Add missing GitHub token usage

### DIFF
--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Code Review
-        uses: tarmojussila/minimax-code-review@main
+        uses: tarmojussila/minimax-code-review@bugfix/github-token
         with:
           MINIMAX_API_KEY: ${{ secrets.MINIMAX_API_KEY }}
           MINIMAX_MODEL: ${{ vars.MINIMAX_MODEL }}

--- a/.github/workflows/ai-review.yml
+++ b/.github/workflows/ai-review.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Code Review
-        uses: tarmojussila/minimax-code-review@bugfix/github-token
+        uses: tarmojussila/minimax-code-review@main
         with:
           MINIMAX_API_KEY: ${{ secrets.MINIMAX_API_KEY }}
           MINIMAX_MODEL: ${{ vars.MINIMAX_MODEL }}

--- a/action.yml
+++ b/action.yml
@@ -8,6 +8,10 @@ inputs:
     description: "MiniMax AI model"
     required: false
     default: "MiniMax-M2.5"
+  GITHUB_TOKEN:
+    description: "GitHub token for posting PR comments"
+    required: false
+    default: ${{ github.token }}
 runs:
   using: "node20"
   main: "dist/index.js"

--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,7 @@ inputs:
     required: false
     default: "MiniMax-M2.5"
   GITHUB_TOKEN:
-    description: "GitHub token for posting PR comments"
+    description: "GitHub token for API access"
     required: false
     default: ${{ github.token }}
 runs:

--- a/dist/index.js
+++ b/dist/index.js
@@ -31900,7 +31900,7 @@ async function run() {
   try {
     const apiKey = core.getInput('MINIMAX_API_KEY', { required: true });
     const model = core.getInput('MINIMAX_MODEL') || 'MiniMax-M2.5';
-    const token = process.env.GITHUB_TOKEN;
+    const token = core.getInput('GITHUB_TOKEN') || process.env.GITHUB_TOKEN;
 
     const octokit = github.getOctokit(token);
     const context = github.context;

--- a/src/index.js
+++ b/src/index.js
@@ -64,7 +64,7 @@ async function run() {
   try {
     const apiKey = core.getInput('MINIMAX_API_KEY', { required: true });
     const model = core.getInput('MINIMAX_MODEL') || 'MiniMax-M2.5';
-    const token = process.env.GITHUB_TOKEN;
+    const token = core.getInput('GITHUB_TOKEN') || process.env.GITHUB_TOKEN;
 
     const octokit = github.getOctokit(token);
     const context = github.context;


### PR DESCRIPTION
This pull request adds support for specifying a GitHub token as an input to the action, improving flexibility in how the token is provided. The main changes are in the action's input definition and how the token is retrieved in the code.

**Action input improvements:**

* Added a new optional input `GITHUB_TOKEN` to `action.yml`, with a default value set to `${{ github.token }}`.

**Token retrieval logic:**

* Updated `src/index.js` to fetch the GitHub token from the new input (`GITHUB_TOKEN`) if provided, otherwise falling back to the environment variable.