### PR TITLE
Add exclude patterns and max diff char limit for large PRs

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Code Review
-        uses: tarmojussila/minimax-code-review@feature/exclude-patterns-max-diffs
+        uses: tarmojussila/minimax-code-review@v0.4.0
         with:
           MINIMAX_API_KEY: ${{ secrets.MINIMAX_API_KEY }}
           MINIMAX_MODEL: ${{ vars.MINIMAX_MODEL }}

--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Code Review
-        uses: tarmojussila/minimax-code-review@v0.3.0
+        uses: tarmojussila/minimax-code-review@feature/exclude-patterns-max-diffs
         with:
           MINIMAX_API_KEY: ${{ secrets.MINIMAX_API_KEY }}
           MINIMAX_MODEL: ${{ vars.MINIMAX_MODEL }}

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Code Review
-        uses: tarmojussila/minimax-code-review@v0.3.0
+        uses: tarmojussila/minimax-code-review@v0.4.0
         with:
           MINIMAX_API_KEY: ${{ secrets.MINIMAX_API_KEY }}
 ```
@@ -88,7 +88,7 @@ Instead of using default values for `MINIMAX_MODEL`, `MINIMAX_SYSTEM_PROMPT`, an
 
 ```yaml
       - name: Code Review
-        uses: tarmojussila/minimax-code-review@v0.3.0
+        uses: tarmojussila/minimax-code-review@v0.4.0
         with:
           MINIMAX_API_KEY: ${{ secrets.MINIMAX_API_KEY }}
           MINIMAX_MODEL: ${{ vars.MINIMAX_MODEL }}

--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@ jobs:
 | `MINIMAX_MODEL` | No | `MiniMax-M2.5` | MiniMax model to use for review |
 | `MINIMAX_SYSTEM_PROMPT` | No | See below | Custom system prompt for the AI reviewer |
 | `MINIMAX_REVIEWER_NAME` | No | `MiniMax Code Review` | Name shown in the review comment header |
+| `EXCLUDE_PATTERNS` | No | `*.lock,package-lock.json,yarn.lock,pnpm-lock.yaml` | Comma-separated file patterns to exclude from review |
+| `MAX_DIFF_CHARS` | No | `0` (unlimited) | Maximum total characters for the diff sent to the API |
 
 The default system prompt is:
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -41,7 +41,7 @@ Do not grant broader permissions than what is listed above.
 For supply chain security, pin the action to a specific release tag rather than a mutable branch name:
 
 ```yaml
-uses: tarmojussila/minimax-code-review@v0.3.0
+uses: tarmojussila/minimax-code-review@v0.4.0
 ```
 
 Avoid using branch names such as `@main` in production workflows.

--- a/action.yml
+++ b/action.yml
@@ -16,6 +16,14 @@ inputs:
     description: "Name shown in the review comment header"
     required: false
     default: "MiniMax Code Review"
+  EXCLUDE_PATTERNS:
+    description: "Comma-separated file patterns to exclude from review (e.g. '*.lock,dist/**,*.min.js')"
+    required: false
+    default: "*.lock,package-lock.json,yarn.lock,pnpm-lock.yaml"
+  MAX_DIFF_CHARS:
+    description: "Maximum total characters for the diff sent to the API (0 = unlimited)"
+    required: false
+    default: "0"
   GITHUB_TOKEN:
     description: "GitHub token for API access"
     required: false

--- a/dist/index.js
+++ b/dist/index.js
@@ -31842,26 +31842,67 @@ const COMMENT_MARKER = '<!-- minimax-code-review -->';
 const MAX_RESPONSE_SIZE = 1024 * 1024;
 const REQUEST_TIMEOUT_MS = 300_000;
 
-async function getDiff(octokit, owner, repo, pull_number) {
+function matchesPattern(filename, pattern) {
+  const escaped = pattern
+    .replace(/[.+^${}()|[\]\\]/g, '\\$&')
+    .replace(/\*\*/g, '\x00')
+    .replace(/\*/g, '[^/]*')
+    .replace(/\x00/g, '.*');
+  const regex = new RegExp(`^${escaped}$`);
+  const basename = filename.split('/').pop();
+  return regex.test(filename) || regex.test(basename);
+}
+
+function filterFiles(files, excludePatterns) {
+  if (!excludePatterns || excludePatterns.length === 0) {
+    return files;
+  }
+  return files.filter(f => !excludePatterns.some(p => matchesPattern(f.filename, p)));
+}
+
+async function getChangedFiles(octokit, owner, repo, pullNumber) {
   const files = [];
   let page = 1;
   while (true) {
     const { data } = await octokit.rest.pulls.listFiles({
       owner,
       repo,
-      pull_number,
+      pull_number: pullNumber,
       per_page: 100,
       page,
     });
     files.push(...data);
-    if (data.length < 100) break;
+    if (data.length < 100) {
+      break;
+    }
     page++;
   }
+  return files;
+}
 
-  return files
-    .filter(f => f.patch)
-    .map(f => `### ${f.filename} (${f.status})\n\`\`\`diff\n${f.patch}\n\`\`\``)
-    .join('\n\n');
+function buildPrompt(files, maxDiffChars) {
+  const patchableFiles = files.filter(f => f.patch);
+  const includedDiffs = [];
+  const skippedFiles = [];
+  let totalChars = 0;
+
+  for (const f of patchableFiles) {
+    const entry = `### ${f.filename} (${f.status})\n\`\`\`diff\n${f.patch}\n\`\`\``;
+    if (maxDiffChars > 0 && totalChars + entry.length > maxDiffChars) {
+      skippedFiles.push(f.filename);
+    } else {
+      includedDiffs.push(entry);
+      totalChars += entry.length;
+    }
+  }
+
+  let diffs = includedDiffs.join('\n\n');
+
+  if (skippedFiles.length > 0) {
+    diffs += `\n\n> **Note:** The following files were excluded because the diff exceeded the \`MAX_DIFF_CHARS\` limit:\n${skippedFiles.map(f => `> - ${f}`).join('\n')}`;
+  }
+
+  return diffs;
 }
 
 async function reviewWithMiniMax(apiKey, model, systemPrompt, diff) {
@@ -31919,69 +31960,79 @@ async function reviewWithMiniMax(apiKey, model, systemPrompt, diff) {
 }
 
 async function run() {
-  try {
-    const apiKey = core.getInput('MINIMAX_API_KEY', { required: true });
-    core.setSecret(apiKey);
-    const model = core.getInput('MINIMAX_MODEL');
-    const systemPrompt = core.getInput('MINIMAX_SYSTEM_PROMPT');
-    const reviewerName = core.getInput('MINIMAX_REVIEWER_NAME');
-    const token = core.getInput('GITHUB_TOKEN');
-    core.setSecret(token);
+  const apiKey = core.getInput('MINIMAX_API_KEY', { required: true });
+  core.setSecret(apiKey);
+  const model = core.getInput('MINIMAX_MODEL');
+  const systemPrompt = core.getInput('MINIMAX_SYSTEM_PROMPT');
+  const reviewerName = core.getInput('MINIMAX_REVIEWER_NAME');
+  const excludePatterns = core.getInput('EXCLUDE_PATTERNS')
+    .split(',')
+    .map(p => p.trim())
+    .filter(p => p.length > 0);
+  const maxDiffChars = parseInt(core.getInput('MAX_DIFF_CHARS'), 10) || 0;
+  const token = core.getInput('GITHUB_TOKEN');
+  core.setSecret(token);
 
-    const octokit = github.getOctokit(token);
-    const { context } = github;
+  const octokit = github.getOctokit(token);
+  const { context } = github;
 
-    if (context.eventName !== 'pull_request') {
-      core.setFailed('This action only works on pull_request events.');
-      return;
+  if (context.eventName !== 'pull_request') {
+    core.setFailed('This action only works on pull_request events.');
+    return;
+  }
+
+  const { owner, repo } = context.repo;
+  const pull_number = context.payload.pull_request.number;
+
+  core.info(`Reviewing PR #${pull_number} with model ${model}...`);
+
+  const files = await getChangedFiles(octokit, owner, repo, pull_number);
+  const filteredFiles = filterFiles(files, excludePatterns);
+
+  if (excludePatterns.length > 0) {
+    const excluded = files.length - filteredFiles.length;
+    if (excluded > 0) {
+      core.info(`Excluded ${excluded} file(s) matching EXCLUDE_PATTERNS.`);
     }
+  }
 
-    const { owner, repo } = context.repo;
-    const pull_number = context.payload.pull_request.number;
+  if (!filteredFiles.some(f => f.patch)) {
+    core.info('No diff found — skipping review.');
+    return;
+  }
 
-    core.info(`Reviewing PR #${pull_number} with model ${model}...`);
+  const diff = buildPrompt(filteredFiles, maxDiffChars);
+  const review = await reviewWithMiniMax(apiKey, model, systemPrompt, diff);
+  const body = `## ${reviewerName}\n\n${review}\n\n${COMMENT_MARKER}`;
 
-    const diff = await getDiff(octokit, owner, repo, pull_number);
+  const { data: comments } = await octokit.rest.issues.listComments({
+    owner,
+    repo,
+    issue_number: pull_number,
+  });
 
-    if (!diff) {
-      core.info('No diff found — skipping review.');
-      return;
-    }
+  const existing = comments.find(c => c.body?.includes(COMMENT_MARKER));
 
-    const review = await reviewWithMiniMax(apiKey, model, systemPrompt, diff);
-    const body = `## ${reviewerName}\n\n${review}\n\n${COMMENT_MARKER}`;
-
-    const { data: comments } = await octokit.rest.issues.listComments({
+  if (existing) {
+    await octokit.rest.issues.updateComment({
+      owner,
+      repo,
+      comment_id: existing.id,
+      body,
+    });
+  } else {
+    await octokit.rest.issues.createComment({
       owner,
       repo,
       issue_number: pull_number,
+      body,
     });
-
-    const existing = comments.find(c => c.body?.includes(COMMENT_MARKER));
-
-    if (existing) {
-      await octokit.rest.issues.updateComment({
-        owner,
-        repo,
-        comment_id: existing.id,
-        body,
-      });
-    } else {
-      await octokit.rest.issues.createComment({
-        owner,
-        repo,
-        issue_number: pull_number,
-        body,
-      });
-    }
-
-    core.info('Code review posted successfully.');
-  } catch (error) {
-    core.setFailed(error.message);
   }
+
+  core.info('Code review posted successfully.');
 }
 
-run();
+run().catch(err => core.setFailed(err.message));
 
 module.exports = __webpack_exports__;
 /******/ })()

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "minimax-code-review",
-  "version": "1.0.0",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "minimax-code-review",
-      "version": "1.0.0",
+      "version": "0.4.0",
       "dependencies": {
         "@actions/core": "^1.10.1",
         "@actions/github": "^6.0.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minimax-code-review",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "AI-powered code review GitHub Action using MiniMax",
   "main": "dist/index.js",
   "scripts": {

--- a/src/index.js
+++ b/src/index.js
@@ -6,26 +6,67 @@ const COMMENT_MARKER = '<!-- minimax-code-review -->';
 const MAX_RESPONSE_SIZE = 1024 * 1024;
 const REQUEST_TIMEOUT_MS = 300_000;
 
-async function getDiff(octokit, owner, repo, pull_number) {
+function matchesPattern(filename, pattern) {
+  const escaped = pattern
+    .replace(/[.+^${}()|[\]\\]/g, '\\$&')
+    .replace(/\*\*/g, '\x00')
+    .replace(/\*/g, '[^/]*')
+    .replace(/\x00/g, '.*');
+  const regex = new RegExp(`^${escaped}$`);
+  const basename = filename.split('/').pop();
+  return regex.test(filename) || regex.test(basename);
+}
+
+function filterFiles(files, excludePatterns) {
+  if (!excludePatterns || excludePatterns.length === 0) {
+    return files;
+  }
+  return files.filter(f => !excludePatterns.some(p => matchesPattern(f.filename, p)));
+}
+
+async function getChangedFiles(octokit, owner, repo, pullNumber) {
   const files = [];
   let page = 1;
   while (true) {
     const { data } = await octokit.rest.pulls.listFiles({
       owner,
       repo,
-      pull_number,
+      pull_number: pullNumber,
       per_page: 100,
       page,
     });
     files.push(...data);
-    if (data.length < 100) break;
+    if (data.length < 100) {
+      break;
+    }
     page++;
   }
+  return files;
+}
 
-  return files
-    .filter(f => f.patch)
-    .map(f => `### ${f.filename} (${f.status})\n\`\`\`diff\n${f.patch}\n\`\`\``)
-    .join('\n\n');
+function buildPrompt(files, maxDiffChars) {
+  const patchableFiles = files.filter(f => f.patch);
+  const includedDiffs = [];
+  const skippedFiles = [];
+  let totalChars = 0;
+
+  for (const f of patchableFiles) {
+    const entry = `### ${f.filename} (${f.status})\n\`\`\`diff\n${f.patch}\n\`\`\``;
+    if (maxDiffChars > 0 && totalChars + entry.length > maxDiffChars) {
+      skippedFiles.push(f.filename);
+    } else {
+      includedDiffs.push(entry);
+      totalChars += entry.length;
+    }
+  }
+
+  let diffs = includedDiffs.join('\n\n');
+
+  if (skippedFiles.length > 0) {
+    diffs += `\n\n> **Note:** The following files were excluded because the diff exceeded the \`MAX_DIFF_CHARS\` limit:\n${skippedFiles.map(f => `> - ${f}`).join('\n')}`;
+  }
+
+  return diffs;
 }
 
 async function reviewWithMiniMax(apiKey, model, systemPrompt, diff) {
@@ -83,66 +124,76 @@ async function reviewWithMiniMax(apiKey, model, systemPrompt, diff) {
 }
 
 async function run() {
-  try {
-    const apiKey = core.getInput('MINIMAX_API_KEY', { required: true });
-    core.setSecret(apiKey);
-    const model = core.getInput('MINIMAX_MODEL');
-    const systemPrompt = core.getInput('MINIMAX_SYSTEM_PROMPT');
-    const reviewerName = core.getInput('MINIMAX_REVIEWER_NAME');
-    const token = core.getInput('GITHUB_TOKEN');
-    core.setSecret(token);
+  const apiKey = core.getInput('MINIMAX_API_KEY', { required: true });
+  core.setSecret(apiKey);
+  const model = core.getInput('MINIMAX_MODEL');
+  const systemPrompt = core.getInput('MINIMAX_SYSTEM_PROMPT');
+  const reviewerName = core.getInput('MINIMAX_REVIEWER_NAME');
+  const excludePatterns = core.getInput('EXCLUDE_PATTERNS')
+    .split(',')
+    .map(p => p.trim())
+    .filter(p => p.length > 0);
+  const maxDiffChars = parseInt(core.getInput('MAX_DIFF_CHARS'), 10) || 0;
+  const token = core.getInput('GITHUB_TOKEN');
+  core.setSecret(token);
 
-    const octokit = github.getOctokit(token);
-    const { context } = github;
+  const octokit = github.getOctokit(token);
+  const { context } = github;
 
-    if (context.eventName !== 'pull_request') {
-      core.setFailed('This action only works on pull_request events.');
-      return;
+  if (context.eventName !== 'pull_request') {
+    core.setFailed('This action only works on pull_request events.');
+    return;
+  }
+
+  const { owner, repo } = context.repo;
+  const pull_number = context.payload.pull_request.number;
+
+  core.info(`Reviewing PR #${pull_number} with model ${model}...`);
+
+  const files = await getChangedFiles(octokit, owner, repo, pull_number);
+  const filteredFiles = filterFiles(files, excludePatterns);
+
+  if (excludePatterns.length > 0) {
+    const excluded = files.length - filteredFiles.length;
+    if (excluded > 0) {
+      core.info(`Excluded ${excluded} file(s) matching EXCLUDE_PATTERNS.`);
     }
+  }
 
-    const { owner, repo } = context.repo;
-    const pull_number = context.payload.pull_request.number;
+  if (!filteredFiles.some(f => f.patch)) {
+    core.info('No diff found — skipping review.');
+    return;
+  }
 
-    core.info(`Reviewing PR #${pull_number} with model ${model}...`);
+  const diff = buildPrompt(filteredFiles, maxDiffChars);
+  const review = await reviewWithMiniMax(apiKey, model, systemPrompt, diff);
+  const body = `## ${reviewerName}\n\n${review}\n\n${COMMENT_MARKER}`;
 
-    const diff = await getDiff(octokit, owner, repo, pull_number);
+  const { data: comments } = await octokit.rest.issues.listComments({
+    owner,
+    repo,
+    issue_number: pull_number,
+  });
 
-    if (!diff) {
-      core.info('No diff found — skipping review.');
-      return;
-    }
+  const existing = comments.find(c => c.body?.includes(COMMENT_MARKER));
 
-    const review = await reviewWithMiniMax(apiKey, model, systemPrompt, diff);
-    const body = `## ${reviewerName}\n\n${review}\n\n${COMMENT_MARKER}`;
-
-    const { data: comments } = await octokit.rest.issues.listComments({
+  if (existing) {
+    await octokit.rest.issues.updateComment({
+      owner,
+      repo,
+      comment_id: existing.id,
+      body,
+    });
+  } else {
+    await octokit.rest.issues.createComment({
       owner,
       repo,
       issue_number: pull_number,
+      body,
     });
-
-    const existing = comments.find(c => c.body?.includes(COMMENT_MARKER));
-
-    if (existing) {
-      await octokit.rest.issues.updateComment({
-        owner,
-        repo,
-        comment_id: existing.id,
-        body,
-      });
-    } else {
-      await octokit.rest.issues.createComment({
-        owner,
-        repo,
-        issue_number: pull_number,
-        body,
-      });
-    }
-
-    core.info('Code review posted successfully.');
-  } catch (error) {
-    core.setFailed(error.message);
   }
+
+  core.info('Code review posted successfully.');
 }
 
-run();
+run().catch(err => core.setFailed(err.message));


### PR DESCRIPTION
PR description

 ## Summary
 - Add `EXCLUDE_PATTERNS` input to exclude files from review by glob pattern (defaults to common lock files)
 - Add `MAX_DIFF_CHARS` input to cap total diff size sent to the API (default `0` = unlimited)
 - Refactor `getDiff()` into `getChangedFiles()` → `filterFiles()` → `buildPrompt()` pipeline
 - Files exceeding the char limit are listed in a note appended to the review prompt

 ## Test plan
 - [x] Verify action runs on a PR with default settings (lock files excluded automatically)
 - [x] Test `EXCLUDE_PATTERNS` with custom patterns (e.g. `dist/**,*.min.js`)
 - [x] Test `MAX_DIFF_CHARS` with a value that forces file skipping, confirm skipped-files note appears
 - [x] Confirm existing behavior unchanged when both inputs use defaults